### PR TITLE
Fixes server errors in python 3.11.5

### DIFF
--- a/server/retriever/splitter.py
+++ b/server/retriever/splitter.py
@@ -57,8 +57,7 @@ class TextSplitter(ABC):
                               every document
         """
         if chunk_overlap > chunk_size:
-            raise ValueError(f"Got a larger chunk overlap ({
-                             chunk_overlap}) than chunk size ({chunk_size}), should be smaller.")
+            raise ValueError(f"Got a larger chunk overlap ({chunk_overlap}) than chunk size ({chunk_size}), should be smaller.")
         self._chunk_size = chunk_size
         self._chunk_overlap = chunk_overlap
         self._length_function = length_function

--- a/server/server.py
+++ b/server/server.py
@@ -87,8 +87,11 @@ def format_messages(messages: List[Dict], indexed_files: Optional[str], instruct
         'personalization', '').strip().replace('\n', '; ')
     response = instructions.get('response', '').strip().replace('\n', '; ')
 
-    context = f"with background knowledge of {
-        indexed_files.strip().replace('\n', '; ')}" if indexed_files else ''
+    bits = indexed_files.strip().replace('\n', '; ')
+    if indexed_files:
+      context = f"with background knowledge of {bits}"
+    else:
+      context = ''
     audience = personalization if personalization else 'general'
     style = response if response else 'technical, accurate, and professional'
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -162,8 +162,7 @@ def generate_step(
         repetition_penalty < 0 or not isinstance(repetition_penalty, float)
     ):
         raise ValueError(
-            f"repetition_penalty must be a non-negative float, got {
-                repetition_penalty}"
+            f"repetition_penalty must be a non-negative float, got {repetition_penalty}"
         )
 
     y = prompt


### PR DESCRIPTION
Ran into some python errors on 3.11.5, looks like it's just from some auto-formatting.

There may be better ways to handle this, but at least this shows you where the gotchas are.

The other issue I saw is that once the initial model download completes, you have to restart it to get it to work, but I'm not sure how to go about fixing that one :)